### PR TITLE
Adding validation checkpoints inside batch() and snapshot() methods.

### DIFF
--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -374,6 +374,7 @@ class Database(object):
         :rtype: :class:`~google.cloud.spanner_v1.database.SnapshotCheckout`
         :returns: new wrapper
         """
+        self._validate()
         return SnapshotCheckout(self, **kw)
 
     def batch(self):
@@ -385,6 +386,7 @@ class Database(object):
         :rtype: :class:`~google.cloud.spanner_v1.database.BatchCheckout`
         :returns: new wrapper
         """
+        self._validate()
         return BatchCheckout(self)
 
     def batch_snapshot(self, read_timestamp=None, exact_staleness=None):
@@ -437,6 +439,26 @@ class Database(object):
                 return session.run_in_transaction(func, *args, **kw)
         finally:
             self._local.transaction_running = False
+
+    def _validate(self):
+        """ A helper check-point to specify inevitable checkout errors
+
+        Throws an exception with the appropriate message if either, the database
+        or the corresponding instance are misspelled or do not exist. This helps
+        prevent possible confusion caused by a less-specific error message returned
+        from the subsequent calling of 'self._database._pool.get()'.
+        """
+        if not self.exists():
+            if not self._instance.exists():
+                raise ValueError(
+                    'Instance "{}" does not exist!'.format(self._instance.instance_id)
+                )
+            else:
+                raise ValueError(
+                    'Database "{}" does not exist in instance "{}"'.format(
+                        self.database_id, self._instance.instance_id
+                    )
+                )
 
 
 class BatchCheckout(object):

--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -441,7 +441,7 @@ class Database(object):
             self._local.transaction_running = False
 
     def _validate(self):
-        """ A helper check-point to specify inevitable checkout errors
+        """ A helper check-point to categorize the inevitable errors
 
         Throws an exception with the appropriate message if either, the database
         or the corresponding instance are misspelled or do not exist. This helps


### PR DESCRIPTION
To fix #8695.

The observed error `400 Invalid CreateSession request' is thrown when the `SnapshotCheckout() ` line `session = self._session = self._database._pool.get()` invokes `BurstyPool.get()` that tries to create a session under an obviously non-existing instance. The proposed way of solving it puts a conditional "check-point" statement just before constructing the `SnapshotCheckout()` object.

Since the `BatchCheckout()` class does exactly the same, the above may apply to the `Database.batch()` factory too. If so, it makes sense to encapsulate the conditional statement in a private helper function, to be called within each of the two factories.