### PR TITLE
GCP-7955 - Bigtable: New 'retry' parameter for 'Table.read_row()'

### DIFF
--- a/bigtable/google/cloud/bigtable/batcher.py
+++ b/bigtable/google/cloud/bigtable/batcher.py
@@ -128,15 +128,15 @@ class MutationsBatcher(object):
             self.mutate(row)
 
     def flush(self):
-        """ Sends the current. batch to Cloud Bigtable.
-        For example:
+        """ Sends the current batch to Cloud Bigtable.
 
+        For example:
         .. literalinclude:: snippets.py
             :start-after: [START bigtable_batcher_flush]
             :end-before: [END bigtable_batcher_flush]
 
         """
-        if len(self.rows) != 0:
+        if self.rows:
             self.table.mutate_rows(self.rows)
             self.total_mutation_count = 0
             self.total_size = 0

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -334,7 +334,7 @@ class Table(object):
             for cluster_id, value_pb in table_pb.cluster_states.items()
         }
 
-    def read_row(self, row_key, filter_=None):
+    def read_row(self, row_key, filter_=None, retry=DEFAULT_RETRY_READ_ROWS):
         """Read a single row from this table.
 
         For example:
@@ -350,6 +350,12 @@ class Table(object):
         :param filter_: (Optional) The filter to apply to the contents of the
                         row. If unset, returns the entire row.
 
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry: (Optional) Retry delay or deadline argument. Override
+            the default via, e.g.:
+            ``DEFAULT_RETRY_READ_ROWS.with_deadline(new_value)`` or
+            ``DEFAULT_RETRY_READ_ROWS.with_delay(new_value)``.
+
         :rtype: :class:`.PartialRowData`, :data:`NoneType <types.NoneType>`
         :returns: The contents of the row if any chunks were returned in
                   the response, otherwise :data:`None`.
@@ -358,7 +364,9 @@ class Table(object):
         """
         row_set = RowSet()
         row_set.add_row_key(row_key)
-        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set))
+        result_iter = iter(
+            self.read_rows(filter_=filter_, row_set=row_set, retry=retry)
+        )
         row = next(result_iter, None)
         if next(result_iter, None) is not None:
             raise ValueError("More than one row was returned.")


### PR DESCRIPTION
Fixes #7955

Bigtable: New 'retry' parameter for 'Table.read_row()' + minor 'batcher.py' update