### PR TITLE
[GCP-7696] Storage: generate_signed_url API documentation misleading for response_type/disposition

### DIFF
--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -321,7 +321,7 @@ def generate_signed_url_v2(
 
     :type response_type: str
     :param response_type: (Optional) Content type of responses to requests for
-                          the signed URL. Ignored if content_type is set.
+                          the signed URL. Ignored if content_type is set on object/blob metadata.
 
     :type response_disposition: str
     :param response_disposition: (Optional) Content disposition of responses to
@@ -466,7 +466,7 @@ def generate_signed_url_v4(
 
     :type response_type: str
     :param response_type: (Optional) Content type of responses to requests for
-                          the signed URL. Ignored if content_type is set.
+                          the signed URL. Ignored if content_type is set on object/blob metadata.
 
     :type response_disposition: str
     :param response_disposition: (Optional) Content disposition of responses to

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -321,8 +321,7 @@ def generate_signed_url_v2(
 
     :type response_type: str
     :param response_type: (Optional) Content type of responses to requests for
-                          the signed URL. Used to over-ride the content type of
-                          the underlying resource.
+                          the signed URL.Ignored if content_type is set.
 
     :type response_disposition: str
     :param response_disposition: (Optional) Content disposition of responses to

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -321,7 +321,7 @@ def generate_signed_url_v2(
 
     :type response_type: str
     :param response_type: (Optional) Content type of responses to requests for
-                          the signed URL.Ignored if content_type is set.
+                          the signed URL. Ignored if content_type is set.
 
     :type response_disposition: str
     :param response_disposition: (Optional) Content disposition of responses to
@@ -466,8 +466,7 @@ def generate_signed_url_v4(
 
     :type response_type: str
     :param response_type: (Optional) Content type of responses to requests for
-                          the signed URL. Used to over-ride the content type of
-                          the underlying resource.
+                          the signed URL. Ignored if content_type is set.
 
     :type response_disposition: str
     :param response_disposition: (Optional) Content disposition of responses to

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -365,7 +365,7 @@ class Blob(_PropertyMixin):
 
         :type response_type: str
         :param response_type: (Optional) Content type of responses to requests
-                              for the signed URL. Ignored if content_type is set.
+                              for the signed URL. Ignored if content_type is set on object/blob metadata.
 
         :type generation: str
         :param generation: (Optional) A value that indicates which generation

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -365,8 +365,7 @@ class Blob(_PropertyMixin):
 
         :type response_type: str
         :param response_type: (Optional) Content type of responses to requests
-                              for the signed URL. Used to over-ride the content
-                              type of the underlying blob/object.
+                              for the signed URL.Ignored if content_type is set.
 
         :type generation: str
         :param generation: (Optional) A value that indicates which generation

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -365,7 +365,7 @@ class Blob(_PropertyMixin):
 
         :type response_type: str
         :param response_type: (Optional) Content type of responses to requests
-                              for the signed URL.Ignored if content_type is set.
+                              for the signed URL. Ignored if content_type is set.
 
         :type generation: str
         :param generation: (Optional) A value that indicates which generation

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -475,7 +475,7 @@ class Client(ClientWithProject):
             versions=versions,
             projection=projection,
             fields=fields,
-            client=self
+            client=self,
         )
 
     def list_buckets(

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -348,9 +348,7 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = "foo~bar"
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket)
-        self.assertEqual(
-            blob.public_url, "https://storage.googleapis.com/name/foo~bar"
-        )
+        self.assertEqual(blob.public_url, "https://storage.googleapis.com/name/foo~bar")
 
     def test_public_url_with_non_ascii(self):
         blob_name = u"winter \N{snowman}"

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -651,6 +651,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_blobs(self):
         from google.cloud.storage.bucket import Bucket
+
         BUCKET_NAME = "bucket-name"
 
         credentials = _make_credentials()
@@ -658,8 +659,8 @@ class TestClient(unittest.TestCase):
         connection = _make_connection({"items": []})
 
         with mock.patch(
-            'google.cloud.storage.client.Client._connection',
-            new_callable=mock.PropertyMock
+            "google.cloud.storage.client.Client._connection",
+            new_callable=mock.PropertyMock,
         ) as client_mock:
             client_mock.return_value = connection
 
@@ -671,11 +672,12 @@ class TestClient(unittest.TestCase):
             connection.api_request.assert_called_once_with(
                 method="GET",
                 path="/b/%s/o" % BUCKET_NAME,
-                query_params={"projection": "noAcl"}
+                query_params={"projection": "noAcl"},
             )
 
     def test_list_blobs_w_all_arguments_and_user_project(self):
         from google.cloud.storage.bucket import Bucket
+
         BUCKET_NAME = "name"
         USER_PROJECT = "user-project-123"
         MAX_RESULTS = 10
@@ -701,8 +703,8 @@ class TestClient(unittest.TestCase):
         connection = _make_connection({"items": []})
 
         with mock.patch(
-            'google.cloud.storage.client.Client._connection',
-            new_callable=mock.PropertyMock
+            "google.cloud.storage.client.Client._connection",
+            new_callable=mock.PropertyMock,
         ) as client_mock:
             client_mock.return_value = connection
 
@@ -721,9 +723,7 @@ class TestClient(unittest.TestCase):
 
             self.assertEqual(blobs, [])
             connection.api_request.assert_called_once_with(
-                method="GET",
-                path="/b/%s/o" % BUCKET_NAME,
-                query_params=EXPECTED
+                method="GET", path="/b/%s/o" % BUCKET_NAME, query_params=EXPECTED
             )
 
     def test_list_buckets_wo_project(self):


### PR DESCRIPTION
Fixes [#7696](https://github.com/googleapis/google-cloud-python/issues/7696)