### PR TITLE
[GCP-8633] Firestore: collection_group query with start_after passing a snapshot

### DIFF
--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -390,6 +390,15 @@ class Query(object):
             all_descendants=self._all_descendants,
         )
 
+    def _has_relation_with(self, snapshot):
+        """
+        Check if given snapshot have relation with the
+        collection that this query applies to.
+        """
+        is_same_collection = snapshot.reference._path[:-1] == self._parent._path
+        has_same_segment = snapshot.reference._path[-2] == self._parent._path[0]
+        return is_same_collection or (self._all_descendants and has_same_segment)
+
     def _cursor_helper(self, document_fields, before, start):
         """Set values to be used for a ``start_at`` or ``end_at`` cursor.
 
@@ -419,7 +428,7 @@ class Query(object):
         if isinstance(document_fields, tuple):
             document_fields = list(document_fields)
         elif isinstance(document_fields, document.DocumentSnapshot):
-            if document_fields.reference._path[:-1] != self._parent._path:
+            if not self._has_relation_with(document_fields):
                 raise ValueError(
                     "Cannot use snapshot from another collection as a cursor."
                 )

--- a/firestore/tests/unit/v1/test_collection.py
+++ b/firestore/tests/unit/v1/test_collection.py
@@ -415,6 +415,25 @@ class TestCollectionReference(unittest.TestCase):
         self.assertIs(query._parent, collection)
         self.assertEqual(query._start_at, (doc_fields, False))
 
+    def test_start_after_snapshot(self):
+        from google.cloud.firestore_v1.query import Query
+
+        client = _make_client()
+        parent_ref = self._make_one("parents", client=client).document("parent")
+
+        child_col = parent_ref.collection("children")
+        child_snapshot = child_col.document("child").get()
+
+        query = (
+            client.collection_group("children")
+            .where("d", "==", "Foo")
+            .start_after(child_snapshot)
+        )
+
+        self.assertIsInstance(query, Query)
+        self.assertEqual(query._parent._path, ("children",))
+        self.assertEqual(query._start_at, (child_snapshot, False))
+
     def test_end_before(self):
         from google.cloud.firestore_v1.query import Query
 


### PR DESCRIPTION
IPR: 8633

Add if-statement to check, if passed snapshot have relation with group
