### PR TITLE
[GCP-8480] Bigtable: 'test_bigtable_create_table' snippet flakes with '504 Deadline Exceeded'.

### DIFF
--- a/bigtable/docs/snippets.py
+++ b/bigtable/docs/snippets.py
@@ -403,7 +403,18 @@ def test_bigtable_create_table():
     table = instance.table("table_my")
     # Define the GC policy to retain only the most recent 2 versions.
     max_versions_rule = column_family.MaxVersionsGCRule(2)
-    table.create(column_families={"cf1": max_versions_rule})
+
+    RETRIES = 4
+    # Retry if deadline exceed error.
+    for retry in range(RETRIES):
+        try:
+            table.create(column_families={"cf1": max_versions_rule})
+            break
+        except Exception as e:
+            if retry == RETRIES - 1:
+                raise e
+            else:
+                time.sleep(2 ** (retry - 1))
     # [END bigtable_create_table]
 
     try:


### PR DESCRIPTION
Addresses [#8480](https://github.com/googleapis/google-cloud-python/issues/8480)

Preliminary discussion can be found [here](https://github.com/sangramql/google-cloud-python/pull/7)