### PR TITLE
BigQuery: Add `client_options` support to Client.

### DIFF
--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -29,14 +29,13 @@ class Connection(_http.JSONConnection):
     :param client_info: (Optional) instance used to generate user agent.
     """
 
-    def __init__(self, client, client_info=None):
-        super(Connection, self).__init__(client, client_info)
+    DEFAULT_API_ENDPOINT = "https://www.googleapis.com"
 
+    def __init__(self, client, client_info=None, api_endpoint=DEFAULT_API_ENDPOINT):
+        super(Connection, self).__init__(client, client_info)
+        self.API_BASE_URL = api_endpoint
         self._client_info.gapic_version = __version__
         self._client_info.client_library_version = __version__
-
-    API_BASE_URL = "https://www.googleapis.com"
-    """The base of the API call URL."""
 
     API_VERSION = "v2"
     """The version of the API, used in building the API call's URL."""

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -171,6 +171,7 @@ class Client(ClientWithProject):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http
         )
+
         kw_args = {"client_info": client_info}
         if client_options:
             if type(client_options) == dict:

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -142,7 +142,7 @@ class Client(ClientWithProject):
             requests. If ``None``, then default info will be used. Generally,
             you only need to set this if you're developing your own library
             or partner tool.
-        client_options (google.api_core.client_options.ClientOptions or dict):
+        client_options (Union[~google.api_core.client_options.ClientOptions, dict]):
             (Optional) Client options used to set user options on the client.
             API Endpoint should be set through client_options.
 

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -40,6 +40,7 @@ from google import resumable_media
 from google.resumable_media.requests import MultipartUpload
 from google.resumable_media.requests import ResumableUpload
 
+import google.api_core.client_options
 import google.api_core.exceptions
 from google.api_core import page_iterator
 import google.cloud._helpers
@@ -141,6 +142,9 @@ class Client(ClientWithProject):
             requests. If ``None``, then default info will be used. Generally,
             you only need to set this if you're developing your own library
             or partner tool.
+        client_options (google.api_core.client_options.ClientOptions or dict):
+            (Optional) Client options used to set user options on the client.
+            API Endpoint should be set through client_options.
 
     Raises:
         google.auth.exceptions.DefaultCredentialsError:
@@ -162,11 +166,22 @@ class Client(ClientWithProject):
         location=None,
         default_query_job_config=None,
         client_info=None,
+        client_options=None,
     ):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http
         )
-        self._connection = Connection(self, client_info=client_info)
+        kw_args = {"client_info": client_info}
+        if client_options:
+            if type(client_options) == dict:
+                client_options = google.api_core.client_options.from_dict(
+                    client_options
+                )
+            if client_options.api_endpoint:
+                api_endpoint = client_options.api_endpoint
+                kw_args["api_endpoint"] = api_endpoint
+
+        self._connection = Connection(self, **kw_args)
         self._location = location
         self._default_query_job_config = default_query_job_config
 

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -30,7 +30,7 @@ version = "1.17.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     'enum34; python_version < "3.4"',
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
     "google-resumable-media >= 0.3.1",
     "protobuf >= 3.6.0",
 ]

--- a/bigquery/tests/unit/test__http.py
+++ b/bigquery/tests/unit/test__http.py
@@ -30,7 +30,13 @@ class TestConnection(unittest.TestCase):
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._make_one(object())
-        URI = "/".join([conn.API_BASE_URL, "bigquery", conn.API_VERSION, "foo"])
+        URI = "/".join([conn.DEFAULT_API_ENDPOINT, "bigquery", conn.API_VERSION, "foo"])
+        self.assertEqual(conn.build_api_url("/foo"), URI)
+
+    def test_build_api_url_w_custom_endpoint(self):
+        custom_endpoint = "https://www.foo-googleapis.com"
+        conn = self._make_one(object(), api_endpoint=custom_endpoint)
+        URI = "/".join([custom_endpoint, "bigquery", conn.API_VERSION, "foo"])
         self.assertEqual(conn.build_api_url("/foo"), URI)
 
     def test_build_api_url_w_extra_query_params(self):

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -116,7 +116,6 @@ class TestClient(unittest.TestCase):
         )
 
     def test_ctor_w_empty_client_options(self):
-        from google.cloud.bigquery._http import Connection
         from google.api_core.client_options import ClientOptions
 
         creds = _make_credentials()
@@ -133,8 +132,6 @@ class TestClient(unittest.TestCase):
         )
 
     def test_ctor_w_client_options_dict(self):
-        from google.cloud.bigquery._http import Connection
-        from google.api_core.client_options import ClientOptions
 
         creds = _make_credentials()
         http = object()
@@ -150,7 +147,6 @@ class TestClient(unittest.TestCase):
         )
 
     def test_ctor_w_client_options_object(self):
-        from google.cloud.bigquery._http import Connection
         from google.api_core.client_options import ClientOptions
 
         creds = _make_credentials()

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -106,11 +106,7 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         http = object()
-        client = self._make_one(
-            project=self.PROJECT,
-            credentials=creds,
-            _http=http,
-        )
+        client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -110,14 +110,14 @@ class TestClient(unittest.TestCase):
             project=self.PROJECT,
             credentials=creds,
             _http=http,
-            client_options={"api_endpoint": "https://www.foo-googleapis.com"},
+            client_options={"api_endpoint": Connection.DEFAULT_API_ENDPOINT},
         )
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)
         self.assertIsNone(client.location)
         self.assertEqual(
-            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
+            client._connection.API_BASE_URL, Connection.DEFAULT_API_ENDPOINT
         )
 
     def test_ctor_w_empty_client_options(self):
@@ -147,7 +147,7 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         http = object()
-        client_options = ClientOptions(api_endpoint="https://www.foo-googleapis.com")
+        client_options = ClientOptions(Connection.DEFAULT_API_ENDPOINT)
         client = self._make_one(
             project=self.PROJECT,
             credentials=creds,
@@ -159,7 +159,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(client._connection.http, http)
         self.assertIsNone(client.location)
         self.assertEqual(
-            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
+            client._connection.API_BASE_URL, Connection.DEFAULT_API_ENDPOINT
         )
 
     def test_ctor_w_location(self):

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -106,11 +106,61 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=creds,
+            _http=http,
+            client_options={"api_endpoint": "https://www.foo-googleapis.com"},
+        )
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)
         self.assertIsNone(client.location)
+        self.assertEqual(
+            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
+        )
+
+    def test_ctor_w_empty_client_options(self):
+        from google.cloud.bigquery._http import Connection
+        from google.api_core.client_options import ClientOptions
+
+        creds = _make_credentials()
+        http = object()
+        client_options = ClientOptions()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=creds,
+            _http=http,
+            client_options=client_options,
+        )
+        self.assertIsInstance(client._connection, Connection)
+        self.assertIs(client._connection.credentials, creds)
+        self.assertIs(client._connection.http, http)
+        self.assertIsNone(client.location)
+        self.assertEqual(
+            client._connection.API_BASE_URL, client._connection.DEFAULT_API_ENDPOINT
+        )
+
+    def test_ctor_w_client_options_object(self):
+        from google.cloud.bigquery._http import Connection
+        from google.api_core.client_options import ClientOptions
+
+        creds = _make_credentials()
+        http = object()
+        client_options = ClientOptions(api_endpoint="https://www.foo-googleapis.com")
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=creds,
+            _http=http,
+            client_options=client_options,
+        )
+        self.assertIsInstance(client._connection, Connection)
+        self.assertIs(client._connection.credentials, creds)
+        self.assertIs(client._connection.http, http)
+        self.assertIsNone(client.location)
+        self.assertEqual(
+            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
+        )
 
     def test_ctor_w_location(self):
         from google.cloud.bigquery._http import Connection

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -110,7 +110,6 @@ class TestClient(unittest.TestCase):
             project=self.PROJECT,
             credentials=creds,
             _http=http,
-            client_options={"api_endpoint": Connection.DEFAULT_API_ENDPOINT},
         )
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
@@ -133,12 +132,25 @@ class TestClient(unittest.TestCase):
             _http=http,
             client_options=client_options,
         )
-        self.assertIsInstance(client._connection, Connection)
-        self.assertIs(client._connection.credentials, creds)
-        self.assertIs(client._connection.http, http)
-        self.assertIsNone(client.location)
         self.assertEqual(
             client._connection.API_BASE_URL, client._connection.DEFAULT_API_ENDPOINT
+        )
+
+    def test_ctor_w_client_options_dict(self):
+        from google.cloud.bigquery._http import Connection
+        from google.api_core.client_options import ClientOptions
+
+        creds = _make_credentials()
+        http = object()
+        client_options = {"api_endpoint": "https://www.foo-googleapis.com"}
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=creds,
+            _http=http,
+            client_options=client_options,
+        )
+        self.assertEqual(
+            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
         )
 
     def test_ctor_w_client_options_object(self):
@@ -147,19 +159,15 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         http = object()
-        client_options = ClientOptions(Connection.DEFAULT_API_ENDPOINT)
+        client_options = ClientOptions(api_endpoint="https://www.foo-googleapis.com")
         client = self._make_one(
             project=self.PROJECT,
             credentials=creds,
             _http=http,
             client_options=client_options,
         )
-        self.assertIsInstance(client._connection, Connection)
-        self.assertIs(client._connection.credentials, creds)
-        self.assertIs(client._connection.http, http)
-        self.assertIsNone(client.location)
         self.assertEqual(
-            client._connection.API_BASE_URL, Connection.DEFAULT_API_ENDPOINT
+            client._connection.API_BASE_URL, "https://www.foo-googleapis.com"
         )
 
     def test_ctor_w_location(self):


### PR DESCRIPTION
Addresses [#8475](https://github.com/googleapis/google-cloud-python/issues/8475)

Some nox tests/unittests/pytests still failing on my PC. According to the trace its not the fault of my chgs.