### PR TITLE
[GCP-8467] Storage: Allow tracking upload progress.

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -475,7 +475,7 @@ class Client(ClientWithProject):
             versions=versions,
             projection=projection,
             fields=fields,
-            client=self
+            client=self,
         )
 
     def list_buckets(

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -348,9 +348,7 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = "foo~bar"
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket)
-        self.assertEqual(
-            blob.public_url, "https://storage.googleapis.com/name/foo~bar"
-        )
+        self.assertEqual(blob.public_url, "https://storage.googleapis.com/name/foo~bar")
 
     def test_public_url_with_non_ascii(self):
         blob_name = u"winter \N{snowman}"
@@ -872,6 +870,7 @@ class Test_Blob(unittest.TestCase):
         client = mock.Mock(_credentials=_make_credentials(), spec=["_credentials"])
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
+        self.assertEqual(blob.progress, 0.0)
 
         # Modify the blob so there there will be 2 chunks of size 3.
         blob._CHUNK_SIZE_MULTIPLE = 1
@@ -884,6 +883,7 @@ class Test_Blob(unittest.TestCase):
         blob._do_download(transport, file_obj, download_url, headers)
         # Make sure the download was as expected.
         self.assertEqual(file_obj.getvalue(), b"abcdef")
+        self.assertEqual(blob.progress, 1.0)
 
         # Check that the transport was called exactly twice.
         self.assertEqual(transport.request.call_count, 2)
@@ -1622,6 +1622,7 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(u"blob-name", bucket=bucket)
         blob.chunk_size = blob._CHUNK_SIZE_MULTIPLE
         self.assertIsNotNone(blob.chunk_size)
+        self.assertEqual(blob.progress, 0.0)
 
         # Data to be uploaded.
         data = b"<html>" + (b"A" * blob.chunk_size) + b"</html>"
@@ -1650,6 +1651,7 @@ class Test_Blob(unittest.TestCase):
         # Check the returned values.
         self.assertIs(response, responses[2])
         self.assertEqual(stream.tell(), total_bytes)
+        self.assertEqual(blob.progress, 1.0)
 
         # Check the mocks.
         call0 = self._do_resumable_upload_call0(

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -651,6 +651,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_blobs(self):
         from google.cloud.storage.bucket import Bucket
+
         BUCKET_NAME = "bucket-name"
 
         credentials = _make_credentials()
@@ -658,8 +659,8 @@ class TestClient(unittest.TestCase):
         connection = _make_connection({"items": []})
 
         with mock.patch(
-            'google.cloud.storage.client.Client._connection',
-            new_callable=mock.PropertyMock
+            "google.cloud.storage.client.Client._connection",
+            new_callable=mock.PropertyMock,
         ) as client_mock:
             client_mock.return_value = connection
 
@@ -671,11 +672,12 @@ class TestClient(unittest.TestCase):
             connection.api_request.assert_called_once_with(
                 method="GET",
                 path="/b/%s/o" % BUCKET_NAME,
-                query_params={"projection": "noAcl"}
+                query_params={"projection": "noAcl"},
             )
 
     def test_list_blobs_w_all_arguments_and_user_project(self):
         from google.cloud.storage.bucket import Bucket
+
         BUCKET_NAME = "name"
         USER_PROJECT = "user-project-123"
         MAX_RESULTS = 10
@@ -701,8 +703,8 @@ class TestClient(unittest.TestCase):
         connection = _make_connection({"items": []})
 
         with mock.patch(
-            'google.cloud.storage.client.Client._connection',
-            new_callable=mock.PropertyMock
+            "google.cloud.storage.client.Client._connection",
+            new_callable=mock.PropertyMock,
         ) as client_mock:
             client_mock.return_value = connection
 
@@ -721,9 +723,7 @@ class TestClient(unittest.TestCase):
 
             self.assertEqual(blobs, [])
             connection.api_request.assert_called_once_with(
-                method="GET",
-                path="/b/%s/o" % BUCKET_NAME,
-                query_params=EXPECTED
+                method="GET", path="/b/%s/o" % BUCKET_NAME, query_params=EXPECTED
             )
 
     def test_list_buckets_wo_project(self):


### PR DESCRIPTION
Addresses [GCP-8467]

Changes to the `storage.Blob` class kept minimal - no additional API calls, just extracting values of `resumable_media.ResumableUpload.bytes_uploaded` and `resumable_media.ResumableUpload.total_bytes` in order to calculate the overall progress tracked in a new `storage.Blob.progress` variable. Changes to the unit tests are rudimentary, mostly as sanity checks and to maintain the 100% coverage. A test to validate arbitrary fractions may have disproportionally larger code than what's required by the changes themselves. Not sure whether it is absolutely necessary now, given the simplicity of the calculation, hence decided to keep it as an option for now, TBD upon an explicit request.