### PR TITLE
[Firestore] Updated code to run sys tests on emulator.

### DIFF
--- a/firestore/noxfile.py
+++ b/firestore/noxfile.py
@@ -98,8 +98,9 @@ def system(session):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
     # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
-        session.skip("Credentials must be set via environment variable")
+    if not os.getenv("FIRESTORE_EMULATOR_HOST"):
+        if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
+            session.skip("Credentials must be set via environment variable")
 
     system_test_exists = os.path.exists(system_test_path)
     system_test_folder_exists = os.path.exists(system_test_folder_path)

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -31,6 +31,7 @@ from google.cloud._helpers import _pb_timestamp_to_datetime
 from google.cloud._helpers import UTC
 from google.cloud import firestore_v1 as firestore
 from test_utils.system import unique_resource_id
+from test_utils.system import EmulatorCreds
 
 from time import sleep
 
@@ -40,12 +41,17 @@ RANDOM_ID_REGEX = re.compile("^[a-zA-Z0-9]{20}$")
 MISSING_DOCUMENT = "No document to update: "
 DOCUMENT_EXISTS = "Document already exists: "
 UNIQUE_RESOURCE_ID = unique_resource_id("-")
-
+FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST"
 
 @pytest.fixture(scope=u"module")
 def client():
-    credentials = service_account.Credentials.from_service_account_file(FIRESTORE_CREDS)
-    project = FIRESTORE_PROJECT or credentials.project_id
+    firestore_emulator = os.getenv(FIRESTORE_EMULATOR_HOST)
+    if firestore_emulator is not None:
+        credentials = EmulatorCreds()
+        project = "emulatorproject"
+    else:
+        credentials = service_account.Credentials.from_service_account_file(FIRESTORE_CREDS)
+        project = FIRESTORE_PROJECT or credentials.project_id
     yield firestore.Client(project=project, credentials=credentials)
 
 


### PR DESCRIPTION
Towards [8722]. 
1. Updated sys tests code to make it run on emulator.
5 tests are failing on emulator, all of them are running fine on live firestore service.
Not sure whether we have all firestore functionality available on emulator or not.