### PR TITLE
docs(storage): download_as_string documentation update

### DIFF
--- a/storage/docs/snippets.py
+++ b/storage/docs/snippets.py
@@ -39,7 +39,7 @@ def storage_get_started(client, to_delete):
     bucket = client.get_bucket("bucket-id-here")
     # Then do other things...
     blob = bucket.get_blob("/remote/path/to/file.txt")
-    assert blob.download_as_string() == "My old contents!"
+    assert blob.download_as_string() == b"My old contents!"
     blob.upload_from_string("New contents!")
     blob2 = bucket.blob("/remote/path/storage.txt")
     blob2.upload_from_filename(filename="/local/path.txt")

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -712,7 +712,7 @@ class Blob(_PropertyMixin):
             os.utime(file_obj.name, (mtime, mtime))
 
     def download_as_string(self, client=None, start=None, end=None):
-        """Download the contents of this blob as a bytes object.
+        """Download the contents of this blob as a ``bytes`` object.
 
         If :attr:`user_project` is set on the bucket, bills the API request
         to that project.

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -712,7 +712,7 @@ class Blob(_PropertyMixin):
             os.utime(file_obj.name, (mtime, mtime))
 
     def download_as_string(self, client=None, start=None, end=None):
-        """Download the contents of this blob as a string.
+        """Download the contents of this blob as a bytes object.
 
         If :attr:`user_project` is set on the bucket, bills the API request
         to that project.


### PR DESCRIPTION
IPR: 9290
As I see, the result of the `download_as_string` method is printing in several cases: 
![image](https://user-images.githubusercontent.com/46078689/65671191-761a8b00-e04f-11e9-867e-5e19b5d0d239.png)
![image](https://user-images.githubusercontent.com/46078689/65671241-8fbbd280-e04f-11e9-97d4-2c60897094f7.png)
I'm not sure it is allowed to modify those files and if it needs to. Since after printing the result, user will see a bytes object.
